### PR TITLE
Add support for POWER architecture

### DIFF
--- a/src/readTSC.C
+++ b/src/readTSC.C
@@ -16,13 +16,25 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-long long readTSC(void)
+unsigned long long readTSC(void)
 {
-  union { long long complete; unsigned int part[2]; } ticks;
+  union { unsigned long long complete; unsigned int part[2]; } ticks;
+#ifdef __amd64__
   __asm__ ("rdtsc; mov %%eax,%0;mov %%edx,%1"
             : "=mr" (ticks.part[0]),
               "=mr" (ticks.part[1])
             : /* no inputs */
             : "eax", "edx");
+#elif __powerpc__
+  unsigned int tmp;
+  __asm__ ("0:"
+            "mftbu %[hi32]\n"
+            "mftb %[lo32]\n"
+            "mftbu %[tmp]\n"
+            "cmpw %[tmp],%[hi32]\n"
+            "bne 0b\n"
+            : [hi32] "=r"(ticks.part[0]), [lo32] "=r"(ticks.part[1]),
+            [tmp] "=r"(tmp));
+#endif
   return ticks.complete;
 }


### PR DESCRIPTION
This code reads the Time Base Register on POWER architecture.

Time Base Register requires reading high 32 bits first, then the low 32 bits. Then we read upper 32 bits to check whether it's changed. If it is, we need to reread both values.